### PR TITLE
Removed currency required validator and default currency in code

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: f095bcc583153092f8139f156b84f29e42eef257
+    changeNotes: Currency not required for now.
   - sha: c9b96b1d4e750a9e3cf38cd2d84c5bc120b66b8a
     changeNotes: Stape Microsoft Connection.
   - sha: 99fc58a53bb02e4486518ec86f9abaef4279d09d

--- a/template.js
+++ b/template.js
@@ -208,7 +208,7 @@ function getData(accessToken, developerToken) {
   const phone = data.hashedPhoneNumber;
   const value = data.conversionValue || eventData.value;
 
-  let conversionCurrencyCode = 'USD';
+  let conversionCurrencyCode = '';
   if (data.conversionCurrencyCode) conversionCurrencyCode = data.conversionCurrencyCode;
   else if (eventData.currencyCode) conversionCurrencyCode = eventData.currencyCode;
   else if (eventData.currency) conversionCurrencyCode = eventData.currency;

--- a/template.tpl
+++ b/template.tpl
@@ -208,11 +208,6 @@ ___TEMPLATE_PARAMETERS___
         "name": "conversionCurrencyCode",
         "displayName": "Currency Code",
         "simpleValueType": true,
-        "valueValidators": [
-          {
-            "type": "NON_EMPTY"
-          }
-        ],
         "defaultValue": "USD"
       },
       {
@@ -539,7 +534,7 @@ function getData(accessToken, developerToken) {
   const phone = data.hashedPhoneNumber;
   const value = data.conversionValue || eventData.value;
 
-  let conversionCurrencyCode = 'USD';
+  let conversionCurrencyCode = '';
   if (data.conversionCurrencyCode) conversionCurrencyCode = data.conversionCurrencyCode;
   else if (eventData.currencyCode) conversionCurrencyCode = eventData.currencyCode;
   else if (eventData.currency) conversionCurrencyCode = eventData.currency;


### PR DESCRIPTION
Fixing issue https://github.com/stape-io/microsoft-ads-offline-conversion-tag/issues/5

- removed default value 'USD' in code
- removed validator 'NON_EMPTY' from currency input (its optional in docs)